### PR TITLE
Add INC to INCDIR to the chibios makefile

### DIFF
--- a/tool/chibios/chibios.mk
+++ b/tool/chibios/chibios.mk
@@ -152,7 +152,7 @@ INCDIR = $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
          $(HALINC) $(PLATFORMINC) $(BOARDINC) $(TESTINC) \
          $(CHIBIOS)/os/hal/lib/streams $(CHIBIOS)/os/various \
          $(TMK_DIR) $(COMMON_DIR) $(TMK_DIR)/protocol/chibios \
-         $(TARGET_DIR)
+         $(TARGET_DIR) $(INC)
 
 #
 # Project, sources and paths


### PR DESCRIPTION
Hello,

I have added support for specifying extra include directories from the main project, by appending the INC variable to the list of include directories.

The need for this came when I'm trying to add LCD support for the Infinity Ergodox, using the uGFX library, and needed to add additional include directories. That project in itself is still far from working, but if I get it done, I will add a pull request for that as well.

Best Regards,
Fred Sundvik
