### PR TITLE
Sysv format for ChibiOS arm-none-eabi-size

### DIFF
--- a/tool/chibios/chibios.mk
+++ b/tool/chibios/chibios.mk
@@ -175,7 +175,7 @@ CP   = $(TRGT)objcopy
 AS   = $(TRGT)gcc -x assembler-with-cpp
 AR   = $(TRGT)ar
 OD   = $(TRGT)objdump
-SZ   = $(TRGT)size
+SZ   = $(TRGT)size -A
 HEX  = $(CP) -O ihex
 BIN  = $(CP) -O binary
 


### PR DESCRIPTION
Some new patches to ChibiOS puts heap as it's own section. So the
berkeley format is now useless, as the heap will be included in the
BSS report. The sysv format displays the bss size correctly.

This patch is related to the bug that I reported for the Infinity Ergodox https://github.com/tmk/infinity_ergodox/issues/4.
