### PR TITLE
Add possibility to specify ChibiOS folder

### DIFF
--- a/tool/chibios/chibios.mk
+++ b/tool/chibios/chibios.mk
@@ -83,7 +83,9 @@ endif
 #
 
 # Imported source files and paths
-CHIBIOS = $(TMK_DIR)/tool/chibios/chibios
+ifndef CHIBIOS
+	CHIBIOS = $(TMK_DIR)/tool/chibios/chibios
+endif
 # Startup files.
 include $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC/mk/startup_$(MCU_STARTUP).mk
 # HAL-OSAL files (optional).


### PR DESCRIPTION
I added a the possibility of specifying the location of ChibiOS. This way keyboard projects can include it in their own projects, either as a submodule or a subtree. As the modules no longer need to be nested it would even be possible to have tmk_core as a subtree and ChibiOS as a submodule, both located as subfolders of the main keyboard root folder.

I believe this is the best we can do in order to fix the issue I raised here https://github.com/tmk/tmk_core/issues/6. At least with this patch only the keyboard repository contributors need to care about having compatible ChibiOS and tmk_core versions, instead of all the users.
