### PR TITLE
Add keyboard_connect_hook

### DIFF
--- a/common/hook.h
+++ b/common/hook.h
@@ -21,6 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keyboard.h"
 #include "led.h"
 
+typedef struct _host_driver_t host_driver_t;
+
 /* -------------------------------------
  * Protocol hooks
  * ------------------------------------- */
@@ -28,6 +30,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Called once, very early stage of initialization, just after processor startup. */
 /* Default behaviour: do nothing. */
 void hook_early_init(void);
+
+/* Called once, after USB is initialised */
+/* Should wait for a connection to the host and return a driver that corresponds to that connection */
+/* Default behaviour: wait for a USB connection to the host and return the default driver */
+/* NOTE: Currently implemented only for ChibiOS */
+host_driver_t* hook_keyboard_connect(host_driver_t* default_driver);
 
 /* Called once, very last stage of initialization, just before keyboard loop. */
 /* Default behaviour: do nothing. */

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "report.h"
 
 
-typedef struct {
+typedef struct _host_driver_t {
     uint8_t (*keyboard_leds)(void);
     void (*send_keyboard)(report_keyboard_t *);
     void (*send_mouse)(report_mouse_t *);

--- a/doc/hook.txt
+++ b/doc/hook.txt
@@ -7,6 +7,7 @@ The following hooks are available available:
 Hook function                   | Timing
 --------------------------------|-----------------------------------------------
 `hook_early_init(void)`         | Early in the boot process, before the matrix is initialized and before a connection is made with the host. Thus, this hook has access to very few parameters, but it is a good place to define any custom parameters needed by other early processes.
+`host_driver_t* hook_keyboard_connect(host_driver_t* default_driver)`  | After USB is initialized, should wait for a connection to the host and return a driver that corresponds to that connection. *Default action:* wait for a USB connection to the host and return the default driver. **NOTE:** Currently implemented only for ChibiOS.
 `hook_late_init(void)`          | Near the end of the boot process, after Boot Magic has run and LEDs have been initialized.
 `hook_bootmagic(void)`          | During the Boot Magic window, after EEPROM and Bootloader checks are made, but before any other built-in Boot Magic checks are made.
 `hook_usb_wakeup(void)`         | When the device wakes up from USB suspend state.

--- a/protocol/chibios/main.c
+++ b/protocol/chibios/main.c
@@ -64,6 +64,15 @@ __attribute__((weak))
 void hook_early_init(void) {}
 
 __attribute__((weak))
+host_driver_t* hook_keyboard_connect(host_driver_t* default_driver) {
+  /* Wait until the USB is active */
+  while(USB_DRIVER.state != USB_ACTIVE)
+    chThdSleepMilliseconds(50);
+
+  return default_driver;
+}
+
+__attribute__((weak))
 void hook_late_init(void) {}
 
 __attribute__((weak))
@@ -116,9 +125,7 @@ int main(void) {
   /* init printf */
   init_printf(NULL,sendchar_pf);
 
-  /* Wait until the USB is active */
-  while(USB_DRIVER.state != USB_ACTIVE)
-    chThdSleepMilliseconds(50);
+  host_driver_t* driver = hook_keyboard_connect(&chibios_driver);
 
   /* Do need to wait here!
    * Otherwise the next print might start a transfer on console EP
@@ -131,7 +138,7 @@ int main(void) {
 
   /* init TMK modules */
   keyboard_init();
-  host_set_driver(&chibios_driver);
+  host_set_driver(driver);
 
 #ifdef SLEEP_LED_ENABLE
   sleep_led_init();


### PR DESCRIPTION
With these new hooks in the newapi branch, I was able to almost implement the serial link and visualization for Infinity Ergodox. However I still needed one customization point in order to be able to wait for either the serial link or the USB to become active. Furthermore when the serial link is active, the driver has to be different.

So I added keyboard_connect_hook to support this.
