### PR TITLE
Init ChibiOS printf before early_init

### DIFF
--- a/protocol/chibios/main.c
+++ b/protocol/chibios/main.c
@@ -108,13 +108,13 @@ int main(void) {
   // TESTING
   // chThdCreateStatic(waBlinkerThread, sizeof(waBlinkerThread), NORMALPRIO, blinkerThread, NULL);
 
-  hook_early_init();
-
   /* Init USB */
   init_usb_driver(&USB_DRIVER);
 
   /* init printf */
   init_printf(NULL,sendchar_pf);
+
+  hook_early_init();
 
   /* Wait until the USB is active */
   while(USB_DRIVER.state != USB_ACTIVE)


### PR DESCRIPTION
So that the code does not crash if printf accidently is used before
Some prints might get lost when trying to print too early, but
that's better than crashing, since the order might be hard to
control from a user's perspective. For example the printf might
be called from a thread spanwed by hook_early_init
