### PR TITLE
Add support for multiple drivers and generic main

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,5 +1,6 @@
 COMMON_DIR = common
 SRC +=	$(COMMON_DIR)/host.c \
+	$(COMMON_DIR)/main.c \
 	$(COMMON_DIR)/keyboard.c \
 	$(COMMON_DIR)/action.c \
 	$(COMMON_DIR)/action_tapping.c \

--- a/common/hook.h
+++ b/common/hook.h
@@ -29,6 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Called once, at the program start. */
 /* Default behaviour: returns a configuration for the default driver. */
 host_driver_configuration_t* hook_get_driver_configuration(void);
+
+/* Called immediately at the program start */
+/* Typically not overridden by the user, use hook_early_init instead. */
+/* Different platforms like lufa, prjrc and chibios, typically implement this */
+/* themselves */
 void hook_platform_init(void);
 
 /* Called once, very early stage of initialization, just after processor startup. */

--- a/common/hook.h
+++ b/common/hook.h
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Called once, at the program start. */
 /* Default behaviour: returns a configuration for the default driver. */
 host_driver_configuration_t* hook_get_driver_configuration(void);
-
+void hook_platform_init(void);
 
 /* Called once, very early stage of initialization, just after processor startup. */
 /* Default behaviour: do nothing. */

--- a/common/hook.h
+++ b/common/hook.h
@@ -20,10 +20,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "keyboard.h"
 #include "led.h"
+#include "host_driver.h"
 
 /* -------------------------------------
  * Protocol hooks
  * ------------------------------------- */
+
+/* Called once, at the program start. */
+/* Default behaviour: returns a configuration for the default driver. */
+host_driver_configuration_t* hook_get_driver_configuration(void);
+
 
 /* Called once, very early stage of initialization, just after processor startup. */
 /* Default behaviour: do nothing. */

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -26,8 +26,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 typedef struct {
     void (*init)(void);
     bool (*is_connected)(void);
-    bool (*is_suspended) (void);
-    void (*poll) (void);
+    bool (*is_suspended)(void);
+    void (*poll)(void);
+    bool (*is_remote_wakeup_supported)(void);
+    void (*send_remote_wakeup)(void);
     uint8_t (*keyboard_leds)(void);
     void (*send_keyboard)(report_keyboard_t *);
     void (*send_mouse)(report_mouse_t *);

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -40,6 +40,10 @@ typedef struct {
 typedef struct {
     int num_drivers;
     int connection_delay; // The wait time between connection retries
+    // If a timeout is specified(>0) then the the connection will continue
+    // with the next driver upon timeout. Otherwise all drivers are being
+    // connected in parallel
+    int connection_timeout;
     host_driver_t* drivers[4];
 } host_driver_configuration_t;
 

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -39,6 +39,7 @@ typedef struct {
 
 typedef struct {
     int num_drivers;
+    int connection_delay; // The wait time between connection retries
     host_driver_t* drivers[4];
 } host_driver_configuration_t;
 

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -27,6 +27,7 @@ typedef struct {
     void (*init)(void);
     bool (*is_connected)(void);
     bool (*is_suspended) (void);
+    void (*poll) (void);
     uint8_t (*keyboard_leds)(void);
     void (*send_keyboard)(report_keyboard_t *);
     void (*send_mouse)(report_mouse_t *);

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -19,10 +19,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define HOST_DRIVER_H
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "report.h"
 
 
 typedef struct {
+    void (*init)(void);
+    bool (*is_connected)(void);
+    bool (*is_suspended) (void);
     uint8_t (*keyboard_leds)(void);
     void (*send_keyboard)(report_keyboard_t *);
     void (*send_mouse)(report_mouse_t *);

--- a/common/host_driver.h
+++ b/common/host_driver.h
@@ -24,11 +24,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 typedef struct {
-    void (*init)(void);
+    // Called at the start of the driver connection
+    // Should start to connect to the host. Note that
+    // if the host_driver_configuration asks for a non-parallel
+    // connection, connect might never be called.
+    void (*connect)(void);
+    // Should return true, when the driver is connected
     bool (*is_connected)(void);
+    // Should return true, when the host is suspended from
+    // the driver's point of view
     bool (*is_suspended)(void);
+    // Called regularly, during connection, suspend and normal
+    // keyboard loop. This is automatically called for all drivers
+    // which have got the connect called automatically, even if they
+    // have failed to connect.
+    // So it might not be called when using non-parallel connections
+    // It's also not called for any drivers, that are not part of the
+    // host_driver_configuration.
     void (*poll)(void);
+    // Should return true when host remote wakeup is supported
     bool (*is_remote_wakeup_supported)(void);
+    // Send remote wakeup to the host
     void (*send_remote_wakeup)(void);
     uint8_t (*keyboard_leds)(void);
     void (*send_keyboard)(report_keyboard_t *);
@@ -37,13 +53,44 @@ typedef struct {
     void (*send_consumer)(uint16_t);
 } host_driver_t;
 
+// Represents the host driver configuration of the keyboard
+// Can consist of a single driver, or multiple driver in case
+// there are several ways to contact the host, for example
+// both USB and Bluetooth.
+// Override hook_get_driver_configuration, to return your custom
+// configuration.
 typedef struct {
     int num_drivers;
-    int connection_delay; // The wait time between connection retries
-    // If a timeout is specified(>0) then the the connection will continue
-    // with the next driver upon timeout. Otherwise all drivers are being
-    // connected in parallel
+    // The wait time between connection retries
+    int connection_delay;
+    // There are four modes of connection
+    // If you need to customize the behavior, you could write a
+    // "virtual driver", which internally combines two or more drivers
+    // but handles the connection logic and prioritization internally
+    // 1. The connection_timeout is 0 and try_connect_all is false
+    //    - All drivers are being connected in parallel
+    //      and the first driver that connects gets selected.
+    // 2. The connection timeout is 0 and try_connect_all is true
+    //    - All drivers are bing connected in parallel
+    //    - This continues until all drivers are connected
+    //    - The first driver in the list gets selected
+    // 3. The connection_timeout is >0 and try_connect_all is false
+    //    - Try to connect the first driver until connection_timout
+    //    - If it succeeds before that, select the driver
+    //    - If it fails to connect, then try to connect the second driver
+    //    - Continue with following drivers until a driver gets selected
+    //    - The last driver will not have timeout, and the code will block
+    //      until it connects.
+    // 4. The connection_timout is >0 and try_connect_all is true
+    //    - Try to connect all drivers in parallel, until the timeout
+    //    - If all drivers connect within the timeout, select the first in the list
+    //      and don't wait until the end of the timeout
+    //    - Otherwise wait until the timeout, and select the first one in the list
+    //      that has successfully connected.
+    //    - If no drivers have connected when the timeout expires, wait until the
+    //      one of them connects, and select it immediately
     int connection_timeout;
+    bool try_connect_all;
     host_driver_t* drivers[4];
 } host_driver_configuration_t;
 

--- a/common/main.c
+++ b/common/main.c
@@ -22,14 +22,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "sleep_led.h"
 #include "suspend.h"
 #include "print.h"
+#include "timer.h"
+#include "host.h"
 #ifdef MOUSEKEY_ENABLE
 #include "mousekey.h"
 #endif
 
-void protocol_early_init(void);
-
-
-void mainfunction(void) {
+int main(void) {
+  hook_platform_init();
   host_driver_configuration_t* dc = hook_get_driver_configuration();
 
   for (int i=0; i < dc->num_drivers; i++) {
@@ -40,7 +40,6 @@ void mainfunction(void) {
     }
   }
 
-  protocol_early_init();
   hook_early_init();
   keyboard_setup();
 

--- a/common/main.c
+++ b/common/main.c
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "print.h"
 #include "timer.h"
 #include "host.h"
+#include "matrix.h"
 #ifdef MOUSEKEY_ENABLE
 #include "mousekey.h"
 #endif
@@ -117,6 +118,7 @@ static void keyboard_loop(host_driver_configuration_t* dc) {
         if (host_get_driver()) {
             if(host_get_driver()->is_suspended()) {
                 print("[s]");
+                matrix_power_down();
                 while(host_get_driver() && host_get_driver()->is_suspended()) {
                     hook_usb_suspend_loop();
                     poll_drivers(dc);
@@ -125,6 +127,7 @@ static void keyboard_loop(host_driver_configuration_t* dc) {
                         host_get_driver()->send_remote_wakeup();
                     }
                 }
+                matrix_power_up();
                 /* Woken up */
                 // variables have been already cleared
                 send_keyboard_report();

--- a/common/main.c
+++ b/common/main.c
@@ -154,6 +154,9 @@ int main(void) {
         }
     }
 
+    hook_early_init();
+    keyboard_setup();
+
     host_driver_t* selected_driver = connect_driver(dc);
     /* On ChibiOS
     * Do need to wait here!
@@ -165,9 +168,6 @@ int main(void) {
     wait_ms(50);
 
     print("USB configured.\n");
-
-    hook_early_init();
-    keyboard_setup();
 
     /* init TMK modules */
     keyboard_init();

--- a/common/main.c
+++ b/common/main.c
@@ -28,109 +28,158 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mousekey.h"
 #endif
 
-int main(void) {
-  hook_platform_init();
-  host_driver_configuration_t* dc = hook_get_driver_configuration();
+static uint8_t used_drivers = 0;
 
-  for (int i=0; i < dc->num_drivers; i++) {
-    dc->drivers[i]->init();
-    // Only initialize the first driver if a connection timeout is specified
-    if (dc->connection_timeout > 0) {
-        break;
-    }
-  }
+static inline bool is_serial_connection(host_driver_configuration_t* dc) {
+    return dc->connection_timeout > 0 && dc->try_connect_all == false;
+}
 
-  hook_early_init();
-  keyboard_setup();
-
-  /* Wait until the the host driver is connected */
-  host_driver_t* selected_driver = NULL;
-  int driver_nr = 0;
-  timer_init();
-  uint16_t last_time = timer_read();
-  while(selected_driver == NULL){
-    if (dc->connection_timeout > 0) {
-        // If a connection timeout is specified, only try to one driver at a time
-        dc->drivers[driver_nr]->poll();
-        if (dc->drivers[driver_nr]->is_connected()) {
-            selected_driver = dc->drivers[driver_nr];
+static void poll_drivers(host_driver_configuration_t* dc) {
+    for (int i=0; i<dc->num_drivers; i++) {
+        if (used_drivers & (1u << i)) {
+            dc->drivers[i]->poll();
         }
-        else {
-            // If there's a timeout, continue with the next driver
-            uint16_t elapsed = timer_elapsed(last_time);
-            if (elapsed > dc->connection_timeout) {
-                if (driver_nr < dc->num_drivers  - 1) {
-                    driver_nr++;
-                    last_time = timer_read();
+    }
+}
+
+static host_driver_t* connect_driver(host_driver_configuration_t* dc) {
+    const int timeout = dc->connection_timeout;
+    /* Wait until the the host driver is connected */
+    host_driver_t* selected_driver = NULL;
+    int driver_nr = 0;
+    timer_init();
+    uint16_t last_time = timer_read();
+    while(selected_driver == NULL){
+        if (is_serial_connection(dc)) {
+            // If we are doing a serial connection, try one driver after another,
+            // until we have a connection
+            // This matches case 3. in the host_driver_configuration_t description
+            poll_drivers(dc);
+            if (dc->drivers[driver_nr]->is_connected()) {
+                selected_driver = dc->drivers[driver_nr];
+            }
+            else {
+                // If there's a timeout, continue with the next driver
+                uint16_t elapsed = timer_elapsed(last_time);
+                if (elapsed > timeout) {
+                    if (driver_nr < dc->num_drivers  - 1) {
+                        driver_nr++;
+                        // Since we didn't connect this driver at the start, we have to do it now
+                        dc->drivers[driver_nr]->connect();
+                        used_drivers |= (1u << driver_nr);
+                        last_time = timer_read();
+                    }
                 }
             }
         }
-    }
-    else {
-        // No connection timeout specified, try all drivers in parallel
-        for (int i=0; i<dc->num_drivers; i++) {
-            dc->drivers[i]->poll();
-            if (dc->drivers[i]->is_connected()) {
-                selected_driver = dc->drivers[i];
-                break;
+        else {
+            bool all_connected = true;
+            host_driver_t* first_connected = NULL;
+            for (int i=0; i<dc->num_drivers; i++) {
+                dc->drivers[i]->poll();
+                all_connected &= dc->drivers[i]->is_connected();
+                if (!first_connected && dc->drivers[i]->is_connected()) {
+                    first_connected = dc->drivers[i];
+                }
+            }
+            // Case 1. in the host_driver_configuration_t description
+            // timeout should be zero if this if is taken
+            if (dc->try_connect_all == false && first_connected) {
+                selected_driver = first_connected;
+            }
+            // Case 2. and 4. in the host_driver_configuration_t description
+            // If all drivers are connected, then it's safe to continue
+            // In case 2. when the timeout is zero, this is the only branch
+            // that can be selected. For case 4. this branch can be selected
+            // if all drivers get connected before the timeout.
+            else if (all_connected) {
+                selected_driver = first_connected;
+            }
+            // Case 4. in the host_driver_configuration_t description
+            // If all drivers are not connected when the timeout happens
+            // Then select the first driver that has connected.
+            // Note that he branch is taken even if no driver has connected yet
+            // this is safe, because first_connected will be NULL, and the
+            // connection loop will continue
+            else if(timeout > 0 && timer_elapsed(last_time) > timeout) {
+                selected_driver = first_connected;
             }
         }
+        wait_ms_variable(dc->connection_delay);
     }
-    wait_ms_variable(dc->connection_delay);
-  }
+    return selected_driver;
+}
 
-  /* On ChibiOS
-   * Do need to wait here!
-   * Otherwise the next print might start a transfer on console EP
-   * before the USB is completely ready, which sometimes causes
-   * HardFaults.
-   * Does no harm on other platforms, so just always wait
-   */
-  wait_ms(50);
-
-  print("USB configured.\n");
-
-  /* init TMK modules */
-  keyboard_init();
-  host_set_driver(selected_driver);
-
-#ifdef SLEEP_LED_ENABLE
-  sleep_led_init();
-#endif
-
-  print("Keyboard start.\n");
-
-  hook_late_init();
-
-  /* Main loop */
-  while(true) {
-
-    host_driver_t* host_driver = host_get_driver();
-    if (host_driver) {
-      if(host_driver->is_suspended()) {
-        print("[s]");
-        while(host_driver->is_suspended()) {
-          hook_usb_suspend_loop();
-          for (int i=0; i<dc->num_drivers; i++) {
-            dc->drivers[i]->poll();
-          }
-          /* Remote wakeup */
-          if((host_driver->is_remote_wakeup_supported()) && suspend_wakeup_condition()) {
-            host_driver->send_remote_wakeup();
-          }
+static void keyboard_loop(host_driver_configuration_t* dc) {
+    // make sure that you always use host_get_driver()
+    // since polling and keyboard task might change it
+    while(true) {
+        if (host_get_driver()) {
+            if(host_get_driver()->is_suspended()) {
+                print("[s]");
+                while(host_get_driver() && host_get_driver()->is_suspended()) {
+                    hook_usb_suspend_loop();
+                    poll_drivers(dc);
+                    /* Remote wakeup */
+                    if(host_get_driver() && host_get_driver()->is_remote_wakeup_supported() && suspend_wakeup_condition()) {
+                        host_get_driver()->send_remote_wakeup();
+                    }
+                }
+                /* Woken up */
+                // variables have been already cleared
+                send_keyboard_report();
+                #ifdef MOUSEKEY_ENABLE
+                mousekey_send();
+                #endif /* MOUSEKEY_ENABLE */
+            }
         }
-        /* Woken up */
-        // variables have been already cleared
-        send_keyboard_report();
-#ifdef MOUSEKEY_ENABLE
-        mousekey_send();
-#endif /* MOUSEKEY_ENABLE */
-      }
+
+        keyboard_task();
+        poll_drivers(dc);
+    }
+}
+
+int main(void) {
+    hook_platform_init();
+    host_driver_configuration_t* dc = hook_get_driver_configuration();
+
+    for (int i=0; i < dc->num_drivers; i++) {
+        used_drivers |= (1u << i);
+        dc->drivers[i]->connect();
+        // Only initialize the first driver if a connection timeout is specified
+        // and try_connect_all is false, we are going to do a serial connection in
+        // that case
+        if (is_serial_connection(dc)) {
+            break;
+        }
     }
 
-    keyboard_task();
-    for (int i=0; i<dc->num_drivers; i++) {
-      dc->drivers[i]->poll();
-    }
-  }
+    host_driver_t* selected_driver = connect_driver(dc);
+    /* On ChibiOS
+    * Do need to wait here!
+    * Otherwise the next print might start a transfer on console EP
+    * before the USB is completely ready, which sometimes causes
+    * HardFaults.
+    * Does no harm on other platforms, so just always wait
+    */
+    wait_ms(50);
+
+    print("USB configured.\n");
+
+    hook_early_init();
+    keyboard_setup();
+
+    /* init TMK modules */
+    keyboard_init();
+    host_set_driver(selected_driver);
+
+    #ifdef SLEEP_LED_ENABLE
+    sleep_led_init();
+    #endif
+
+    print("Keyboard start.\n");
+
+    hook_late_init();
+
+    keyboard_loop(dc);
 }

--- a/common/main.h
+++ b/common/main.h
@@ -15,8 +15,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <stddef.h>
+#include "hook.h"
 #include "wait.h"
 #include "action_util.h"
+#include "sleep_led.h"
+#include "suspend.h"
+#include "print.h"
 #ifdef MOUSEKEY_ENABLE
 #include "mousekey.h"
 #endif

--- a/common/main.h
+++ b/common/main.h
@@ -16,6 +16,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "wait.h"
+#include "action_util.h"
+#ifdef MOUSEKEY_ENABLE
+#include "mousekey.h"
+#endif
 
 void protocol_early_init(void);
 
@@ -29,6 +33,7 @@ void mainfunction(void) {
 
   protocol_early_init();
   hook_early_init();
+  keyboard_setup();
 
   /* Wait until the the host driver is connected */
   host_driver_t* selected_driver = NULL;

--- a/common/main.h
+++ b/common/main.h
@@ -50,7 +50,7 @@ void mainfunction(void) {
             break;
         }
     }
-    wait_ms(50);
+    wait_ms_variable(dc->connection_delay);
   }
 
   /* On ChibiOS

--- a/common/main.h
+++ b/common/main.h
@@ -1,0 +1,100 @@
+/*
+Copyright 2016 Fred Sundvik
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "wait.h"
+
+void protocol_early_init(void);
+
+
+void mainfunction(void) {
+  host_driver_configuration_t* dc = hook_get_driver_configuration();
+
+  for (int i=0; i < dc->num_drivers; i++) {
+    dc->drivers[i]->init();
+  }
+
+  protocol_early_init();
+  hook_early_init();
+
+  /* Wait until the the host driver is connected */
+  host_driver_t* selected_driver = NULL;
+  while(selected_driver == NULL){
+    for (int i=0; i<dc->num_drivers; i++) {
+        dc->drivers[i]->poll();
+        if (dc->drivers[i]->is_connected()) {
+            selected_driver = dc->drivers[i];
+            break;
+        }
+    }
+    wait_ms(50);
+  }
+
+  /* On ChibiOS
+   * Do need to wait here!
+   * Otherwise the next print might start a transfer on console EP
+   * before the USB is completely ready, which sometimes causes
+   * HardFaults.
+   * Does no harm on other platforms, so just always wait
+   */
+  wait_ms(50);
+
+  print("USB configured.\n");
+
+  /* init TMK modules */
+  keyboard_init();
+  host_set_driver(selected_driver);
+
+#ifdef SLEEP_LED_ENABLE
+  sleep_led_init();
+#endif
+
+  print("Keyboard start.\n");
+
+  hook_late_init();
+
+  /* Main loop */
+  while(true) {
+
+    host_driver_t* host_driver = host_get_driver();
+    if (host_driver) {
+      if(host_driver->is_suspended()) {
+        print("[s]");
+        while(host_driver->is_suspended()) {
+          hook_usb_suspend_loop();
+          for (int i=0; i<dc->num_drivers; i++) {
+            dc->drivers[i]->poll();
+          }
+          /* Remote wakeup */
+          if((host_driver->is_remote_wakeup_supported()) && suspend_wakeup_condition()) {
+            host_driver->send_remote_wakeup();
+          }
+        }
+        /* Woken up */
+        // variables have been already cleared
+        send_keyboard_report();
+#ifdef MOUSEKEY_ENABLE
+        mousekey_send();
+#endif /* MOUSEKEY_ENABLE */
+      }
+    }
+
+    keyboard_task();
+    for (int i=0; i<dc->num_drivers; i++) {
+      dc->drivers[i]->poll();
+    }
+  }
+}

--- a/common/wait.h
+++ b/common/wait.h
@@ -9,12 +9,19 @@ extern "C" {
 #   include <util/delay.h>
 #   define wait_ms(ms)  _delay_ms(ms)
 #   define wait_us(us)  _delay_us(us)
+static inline void wait_ms_variable(unsigned int ms) {
+    while(ms--) {
+        _delay_ms(1);
+    }
+}
 #elif defined(PROTOCOL_CHIBIOS) /* __AVR__ */
 #   include "ch.h"
 #   define wait_ms(ms) chThdSleepMilliseconds(ms)
 #   define wait_us(us) chThdSleepMicroseconds(us)
+#   define wait_ms_variable(ms) wait_ms(ms)
 #elif defined(__arm__) /* __AVR__ */
 #   include "wait_api.h"
+#   define wait_ms_variable(ms) wait_ms(ms)
 #endif /* __AVR__ */
 
 #ifdef __cplusplus

--- a/doc/hook.txt
+++ b/doc/hook.txt
@@ -6,6 +6,7 @@ The following hooks are available available:
 
 Hook function                   | Timing
 --------------------------------|-----------------------------------------------
+`host_driver_configuration_t* hook_get_driver_configuration(void)` | At the start of the program, should return a valid configuration, see the code documentation for `host_driver_configuration` for more information. 
 `hook_early_init(void)`         | Early in the boot process, before the matrix is initialized and before a connection is made with the host. Thus, this hook has access to very few parameters, but it is a good place to define any custom parameters needed by other early processes.
 `hook_late_init(void)`          | Near the end of the boot process, after Boot Magic has run and LEDs have been initialized.
 `hook_bootmagic(void)`          | During the Boot Magic window, after EEPROM and Bootloader checks are made, but before any other built-in Boot Magic checks are made.

--- a/protocol/bluefruit.mk
+++ b/protocol/bluefruit.mk
@@ -1,7 +1,7 @@
 BLUEFRUIT_DIR = protocol/bluefruit
 PJRC_DIR = protocol/pjrc
 
-SRC +=	$(BLUEFRUIT_DIR)/main.c \
+SRC +=	$(BLUEFRUIT_DIR)/bluefruithooks.c \
 	$(BLUEFRUIT_DIR)/bluefruit.c \
 	serial_uart.c \
 	$(PJRC_DIR)/pjrc.c \

--- a/protocol/bluefruit/bluefruit.h
+++ b/protocol/bluefruit/bluefruit.h
@@ -23,6 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host_driver.h"
 
 
-host_driver_t *bluefruit_driver(void);
+extern host_driver_t bluefruit_driver;
 
 #endif

--- a/protocol/bluefruit/bluefruithooks.c
+++ b/protocol/bluefruit/bluefruithooks.c
@@ -33,7 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "suspend.h"
 #include "bluefruit.h"
 #include "pjrc.h"
-#include "main.h"
 
 #define CPU_PRESCALE(n)    (CLKPR = 0x80, CLKPR = (n))
 
@@ -41,8 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BLUEFRUIT_HOST_DRIVER   1
 #define PJRC_HOST_DRIVER        2
 
-int main(void)
-{   
+void hook_platform_init(void) {
 
     CPU_PRESCALE(0);
 
@@ -53,7 +51,6 @@ int main(void)
     PORTB = _BV(PB0);
 
     print_set_sendchar(sendchar);
-    mainfunction();
 }
 
 static host_driver_configuration_t driver_configuration = {

--- a/protocol/bluefruit/bluefruithooks.c
+++ b/protocol/bluefruit/bluefruithooks.c
@@ -57,6 +57,7 @@ static host_driver_configuration_t driver_configuration = {
   .num_drivers = 2,
   .connection_delay = 50,
   .connection_timeout  = 2000,
+  .try_connect_all = false,
   .drivers = {&pjrc_driver, &bluefruit_driver}
 };
 

--- a/protocol/chibios/chibios.h
+++ b/protocol/chibios/chibios.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2011 Jun Wako <wakojun@gmail.com>
+Copyright 2016 Fred Sundvik
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -15,28 +15,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef HOST_DRIVER_H
-#define HOST_DRIVER_H
+#ifndef CHIBIOS_H
+#define CHIBIOS_H
 
-#include <stdint.h>
-#include <stdbool.h>
-#include "report.h"
+extern host_driver_t chibios_usb_driver;
 
-
-typedef struct {
-    void (*init)(void);
-    bool (*is_connected)(void);
-    bool (*is_suspended) (void);
-    uint8_t (*keyboard_leds)(void);
-    void (*send_keyboard)(report_keyboard_t *);
-    void (*send_mouse)(report_mouse_t *);
-    void (*send_system)(uint16_t);
-    void (*send_consumer)(uint16_t);
-} host_driver_t;
-
-typedef struct {
-    int num_drivers;
-    host_driver_t* drivers[4];
-} host_driver_configuration_t;
-
-#endif
+#endif /* CHIBIOS_H */

--- a/protocol/chibios/chibioshooks.c
+++ b/protocol/chibios/chibioshooks.c
@@ -76,6 +76,7 @@ host_driver_configuration_t chibios_driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 50,
   .connection_timeout = 0,
+  .try_connect_all = false,
   .drivers = {&chibios_usb_driver}
 };
 

--- a/protocol/chibios/chibioshooks.c
+++ b/protocol/chibios/chibioshooks.c
@@ -37,7 +37,6 @@
 #include "suspend.h"
 #include "hook.h"
 #include "chibios.h"
-#include "main.h"
 
 
 /* -------------------------
@@ -98,11 +97,12 @@ host_driver_configuration_t* hook_get_driver_configuration(void) {
     return &chibios_driver_configuration;
 }
 
-void protocol_early_init(void) {
-  /* init printf */
+void hook_platform_init(void) {
+  /* ChibiOS/RT init */
+  halInit();
+  chSysInit();
   init_printf(NULL,sendchar_pf);
 }
-
 
 /* TESTING
  * Amber LED blinker thread, times are in milliseconds.
@@ -125,15 +125,3 @@ void protocol_early_init(void) {
 // }
 
 
-
-/* Main thread
- */
-int main(void) {
-  /* ChibiOS/RT init */
-  halInit();
-  chSysInit();
-
-  // TESTING
-  // chThdCreateStatic(waBlinkerThread, sizeof(waBlinkerThread), NORMALPRIO, blinkerThread, NULL);
-  mainfunction();
-}

--- a/protocol/chibios/main.c
+++ b/protocol/chibios/main.c
@@ -76,6 +76,7 @@ host_driver_t chibios_usb_driver = {
 host_driver_configuration_t chibios_driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 50,
+  .connection_timeout = 0,
   .drivers = {&chibios_usb_driver}
 };
 

--- a/protocol/chibios/main.c
+++ b/protocol/chibios/main.c
@@ -75,6 +75,7 @@ host_driver_t chibios_usb_driver = {
 
 host_driver_configuration_t chibios_driver_configuration = {
   .num_drivers = 1,
+  .connection_delay = 50,
   .drivers = {&chibios_usb_driver}
 };
 

--- a/protocol/chibios/main.c
+++ b/protocol/chibios/main.c
@@ -108,13 +108,13 @@ int main(void) {
   // TESTING
   // chThdCreateStatic(waBlinkerThread, sizeof(waBlinkerThread), NORMALPRIO, blinkerThread, NULL);
 
-  hook_early_init();
-
   /* Init USB */
   init_usb_driver(&USB_DRIVER);
 
   /* init printf */
   init_printf(NULL,sendchar_pf);
+
+  hook_early_init();
 
   /* Wait until the USB is active */
   while(USB_DRIVER.state != USB_ACTIVE)

--- a/protocol/chibios/usb_main.c
+++ b/protocol/chibios/usb_main.c
@@ -1047,7 +1047,7 @@ bool is_usb_connected(void) {
 }
 
 bool is_usb_suspended(void) {
-    return USB_DRIVER.state == USB_SUSPENDED;
+  return USB_DRIVER.state == USB_SUSPENDED;
 }
 
 /*

--- a/protocol/chibios/usb_main.c
+++ b/protocol/chibios/usb_main.c
@@ -1038,6 +1038,18 @@ void init_usb_driver(USBDriver *usbp) {
 #endif
 }
 
+void init_driver(void) {
+  init_usb_driver(&USB_DRIVER);
+}
+
+bool is_usb_connected(void) {
+  return USB_DRIVER.state == USB_ACTIVE;
+}
+
+bool is_usb_suspended(void) {
+    return USB_DRIVER.state == USB_SUSPENDED;
+}
+
 /*
  * Send remote wakeup packet
  * Note: should not be called from ISR

--- a/protocol/chibios/usb_main.c
+++ b/protocol/chibios/usb_main.c
@@ -1050,12 +1050,15 @@ bool is_usb_suspended(void) {
   return USB_DRIVER.state == USB_SUSPENDED;
 }
 
+bool is_remote_wakeup_supported(void) {
+    return USB_DRIVER.status & 2;
+}
+
 /*
  * Send remote wakeup packet
  * Note: should not be called from ISR
  */
-void send_remote_wakeup(USBDriver *usbp) {
-  (void)usbp;
+void send_remote_wakeup(void) {
 #if defined(K20x) || defined(KL2x)
 #if KINETIS_USB_USE_USB0
   USB0->CTL |= USBx_CTL_RESUME;

--- a/protocol/chibios/usb_main.h
+++ b/protocol/chibios/usb_main.h
@@ -37,7 +37,7 @@
 void init_usb_driver(USBDriver *usbp);
 
 /* Send remote wakeup packet */
-void send_remote_wakeup(USBDriver *usbp);
+void send_remote_wakeup(void);
 
 /* ---------------
  * Keyboard header

--- a/protocol/lufa.mk
+++ b/protocol/lufa.mk
@@ -14,6 +14,7 @@ else
 endif
 
 LUFA_SRC = $(LUFA_DIR)/lufa.c \
+	   $(LUFA_DIR)/lufahooks.c \
 	   $(LUFA_DIR)/descriptor.c \
 	   $(LUFA_SRC_USB)
 

--- a/protocol/lufa/lufa.c
+++ b/protocol/lufa/lufa.c
@@ -52,7 +52,6 @@
 
 #include "descriptor.h"
 #include "lufa.h"
-#include "main.h"
 
 uint8_t keyboard_idle = 0;
 /* 0: Boot Protocol, 1: Report Protocol(default) */
@@ -89,14 +88,6 @@ host_driver_t lufa_driver = {
     send_system,
     send_consumer
 };
-
-static host_driver_configuration_t lufa_driver_configuration = {
-  .num_drivers = 1,
-  .connection_delay = 50,
-  .connection_timeout = 0,
-  .drivers = {&lufa_driver}
-};
-
 
 /*******************************************************************************
  * Console
@@ -578,20 +569,6 @@ int8_t sendchar(uint8_t c)
 }
 #endif
 
-
-/*******************************************************************************
- * main
- ******************************************************************************/
-static void setup_mcu(void)
-{
-    /* Disable watchdog if enabled by bootloader/fuses */
-    MCUSR &= ~(1 << WDRF);
-    wdt_disable();
-
-    /* Disable clock division */
-    clock_prescale_set(clock_div_1);
-}
-
 static void setup_usb(void)
 {
     // Leonardo needs. Without this USB device is not recognized.
@@ -602,9 +579,6 @@ static void setup_usb(void)
     // for Console_Task
     USB_Device_EnableSOFEvents();
     print_set_sendchar(sendchar);
-}
-
-void protocol_early_init(void) {
     sei();
 }
 
@@ -630,47 +604,4 @@ static bool is_remote_wakeup_supported(void) {
 
 static void send_remote_wakeup(void) {
     USB_Device_SendRemoteWakeup();
-}
-
-int main(void)  __attribute__ ((weak));
-int main(void)
-{
-    setup_mcu();
-    mainfunction();
-}
-
-/* hooks */
-__attribute__((weak))
-host_driver_configuration_t* hook_get_driver_configuration(void) {
-    return &lufa_driver_configuration;
-}
-
-__attribute__((weak))
-void hook_early_init(void) {}
-
-__attribute__((weak))
-void hook_late_init(void) {}
-
- __attribute__((weak))
-void hook_usb_suspend_entry(void)
-{
-#ifdef SLEEP_LED_ENABLE
-    sleep_led_enable();
-#endif
-}
-
-__attribute__((weak))
-void hook_usb_suspend_loop(void)
-{
-    suspend_power_down();
-}
-
-__attribute__((weak))
-void hook_usb_wakeup(void)
-{
-#ifdef SLEEP_LED_ENABLE
-    sleep_led_disable();
-    // NOTE: converters may not accept this
-    led_set(host_keyboard_leds());
-#endif
 }

--- a/protocol/lufa/lufa.c
+++ b/protocol/lufa/lufa.c
@@ -93,6 +93,7 @@ host_driver_t lufa_driver = {
 static host_driver_configuration_t lufa_driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 50,
+  .connection_timeout = 0,
   .drivers = {&lufa_driver}
 };
 

--- a/protocol/lufa/lufa.c
+++ b/protocol/lufa/lufa.c
@@ -92,6 +92,7 @@ host_driver_t lufa_driver = {
 
 static host_driver_configuration_t lufa_driver_configuration = {
   .num_drivers = 1,
+  .connection_delay = 50,
   .drivers = {&lufa_driver}
 };
 

--- a/protocol/lufa/lufahooks.c
+++ b/protocol/lufa/lufahooks.c
@@ -23,6 +23,7 @@ static host_driver_configuration_t lufa_driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 50,
   .connection_timeout = 0,
+  .try_connect_all = false,
   .drivers = {&lufa_driver}
 };
 

--- a/protocol/lufa/lufahooks.c
+++ b/protocol/lufa/lufahooks.c
@@ -1,0 +1,75 @@
+/*
+Copyright 2016 Fred Sundvik
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "lufa.h"
+#include "hook.h"
+#include "suspend.h"
+
+static host_driver_configuration_t lufa_driver_configuration = {
+  .num_drivers = 1,
+  .connection_delay = 50,
+  .connection_timeout = 0,
+  .drivers = {&lufa_driver}
+};
+
+/* hooks */
+__attribute__((weak))
+host_driver_configuration_t* hook_get_driver_configuration(void) {
+    return &lufa_driver_configuration;
+}
+
+void hook_platform_init(void) {
+    /* Disable watchdog if enabled by bootloader/fuses */
+    MCUSR &= ~(1 << WDRF);
+    wdt_disable();
+
+    /* Disable clock division */
+    clock_prescale_set(clock_div_1);
+}
+
+__attribute__((weak))
+void hook_early_init(void) {}
+
+__attribute__((weak))
+void hook_late_init(void) {}
+
+ __attribute__((weak))
+void hook_usb_suspend_entry(void)
+{
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_enable();
+#endif
+}
+
+__attribute__((weak))
+void hook_usb_suspend_loop(void)
+{
+    suspend_power_down();
+}
+
+__attribute__((weak))
+void hook_usb_wakeup(void)
+{
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_disable();
+    // NOTE: converters may not accept this
+    led_set(host_keyboard_leds());
+#endif
+}
+
+
+

--- a/protocol/mbed/mbed_driver.cpp
+++ b/protocol/mbed/mbed_driver.cpp
@@ -12,8 +12,21 @@ static void send_keyboard(report_keyboard_t *report);
 static void send_mouse(report_mouse_t *report);
 static void send_system(uint16_t data);
 static void send_consumer(uint16_t data);
+static void init_driver(void) {}
+static bool is_connected(void) {return keyboard.configured();}
+// The HIDKeyboard does not seem to expose the suspend state
+static bool is_suspended(void) {return false;}
+static void poll_usb(void) {}
+static bool is_remote_wakeup_supported() {return false;}
+static void send_remote_wakeup(void) {}
 
 host_driver_t mbed_driver = {
+    init_driver,
+    is_connected,
+    is_suspended,
+    poll_usb,
+    is_remote_wakeup_supported,
+    send_remote_wakeup,
     keyboard_leds,
     send_keyboard,
     send_mouse,

--- a/protocol/pjrc.mk
+++ b/protocol/pjrc.mk
@@ -1,6 +1,6 @@
 PJRC_DIR = protocol/pjrc
 
-SRC +=	$(PJRC_DIR)/main.c \
+SRC +=	$(PJRC_DIR)/pjrchooks.c \
 	$(PJRC_DIR)/pjrc.c \
 	$(PJRC_DIR)/usb_keyboard.c \
 	$(PJRC_DIR)/usb_debug.c \

--- a/protocol/pjrc/main.c
+++ b/protocol/pjrc/main.c
@@ -32,3 +32,15 @@ int main(void)
     CPU_PRESCALE(0);
     mainfunction();
 }
+
+static host_driver_configuration_t driver_configuration = {
+  .num_drivers = 1,
+  .connection_delay = 50,
+  .connection_timeout = 0,
+  .drivers = {&pjrc_driver}
+};
+
+__attribute__((weak))
+host_driver_configuration_t* hook_get_driver_configuration(void) {
+    return &driver_configuration;
+}

--- a/protocol/pjrc/main.c
+++ b/protocol/pjrc/main.c
@@ -21,54 +21,14 @@
  * THE SOFTWARE.
  */
 
-#include <stdbool.h>
 #include <avr/io.h>
-#include <avr/interrupt.h>
-#include <avr/wdt.h>
-#include <util/delay.h>
-#include "keyboard.h"
-#include "usb.h"
-#include "matrix.h"
-#include "print.h"
-#include "debug.h"
-#include "sendchar.h"
-#include "util.h"
-#include "suspend.h"
-#include "host.h"
-#include "pjrc.h"
-
+#include "main.h"
 
 #define CPU_PRESCALE(n)    (CLKPR = 0x80, CLKPR = (n))
-
 
 int main(void)
 {
     // set for 16 MHz clock
     CPU_PRESCALE(0);
-
-    keyboard_setup();
-
-    // Initialize the USB, and then wait for the host to set configuration.
-    // If the Teensy is powered without a PC connected to the USB port,
-    // this will wait forever.
-    usb_init();
-    while (!usb_configured()) /* wait */ ;
-
-    print_set_sendchar(sendchar);
-
-    keyboard_init();
-    host_set_driver(pjrc_driver());
-#ifdef SLEEP_LED_ENABLE
-    sleep_led_init();
-#endif
-    while (1) {
-        while (suspend) {
-            suspend_power_down();
-            if (remote_wakeup && suspend_wakeup_condition()) {
-                usb_remote_wakeup();
-            }
-        }
-
-        keyboard_task(); 
-    }
+    mainfunction();
 }

--- a/protocol/pjrc/pjrc.c
+++ b/protocol/pjrc/pjrc.c
@@ -44,7 +44,7 @@ static bool is_suspended(void) { return suspend; }
 static void poll_usb(void) {}
 static bool is_remote_wakeup_supported(void) {return remote_wakeup;}
 
-static host_driver_t driver = {
+host_driver_t pjrc_driver = {
         usb_init,
         is_connected,
         is_suspended,
@@ -58,25 +58,8 @@ static host_driver_t driver = {
         send_consumer
 };
 
-static host_driver_configuration_t driver_configuration = {
-  .num_drivers = 1,
-  .connection_delay = 50,
-  .drivers = {&driver}
-};
-
-host_driver_t *pjrc_driver(void)
-{
-    return &driver;
-}
-
 void protocol_early_init(void) {
     print_set_sendchar(sendchar);
-}
-
-
-__attribute__((weak))
-host_driver_configuration_t* hook_get_driver_configuration(void) {
-    return &driver_configuration;
 }
 
 static uint8_t keyboard_leds(void) {

--- a/protocol/pjrc/pjrc.c
+++ b/protocol/pjrc/pjrc.c
@@ -58,10 +58,6 @@ host_driver_t pjrc_driver = {
         send_consumer
 };
 
-void protocol_early_init(void) {
-    print_set_sendchar(sendchar);
-}
-
 static uint8_t keyboard_leds(void) {
     return usb_keyboard_leds;
 }
@@ -89,35 +85,5 @@ static void send_consumer(uint16_t data)
 {
 #ifdef EXTRAKEY_ENABLE
     usb_extra_consumer_send(data);
-#endif
-}
-
-__attribute__((weak))
-void hook_early_init(void) {}
-
-__attribute__((weak))
-void hook_late_init(void) {}
-
- __attribute__((weak))
-void hook_usb_suspend_entry(void)
-{
-#ifdef SLEEP_LED_ENABLE
-    sleep_led_enable();
-#endif
-}
-
-__attribute__((weak))
-void hook_usb_suspend_loop(void)
-{
-    suspend_power_down();
-}
-
-__attribute__((weak))
-void hook_usb_wakeup(void)
-{
-#ifdef SLEEP_LED_ENABLE
-    sleep_led_disable();
-    // NOTE: converters may not accept this
-    led_set(host_keyboard_leds());
 #endif
 }

--- a/protocol/pjrc/pjrc.c
+++ b/protocol/pjrc/pjrc.c
@@ -60,6 +60,7 @@ static host_driver_t driver = {
 
 static host_driver_configuration_t driver_configuration = {
   .num_drivers = 1,
+  .connection_delay = 50,
   .drivers = {&driver}
 };
 

--- a/protocol/pjrc/pjrc.h
+++ b/protocol/pjrc/pjrc.h
@@ -21,6 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host_driver.h"
 
 
-host_driver_t *pjrc_driver(void);
+extern host_driver_t pjrc_driver;
 
 #endif

--- a/protocol/pjrc/pjrchooks.c
+++ b/protocol/pjrc/pjrchooks.c
@@ -42,6 +42,7 @@ static host_driver_configuration_t driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 50,
   .connection_timeout = 0,
+  .try_connect_all = false,
   .drivers = {&pjrc_driver}
 };
 

--- a/protocol/pjrc/pjrchooks.c
+++ b/protocol/pjrc/pjrchooks.c
@@ -26,6 +26,8 @@
 #include "pjrc.h"
 #include "suspend.h"
 #include "host.h"
+#include "sendchar.h"
+#include "print.h"
 #ifdef SLEEP_LED_ENABLE
 #include "sleep_led.h"
 #endif

--- a/protocol/pjrc/usb.c
+++ b/protocol/pjrc/usb.c
@@ -34,12 +34,10 @@
 #include "led.h"
 #include "print.h"
 #include "util.h"
-#ifdef SLEEP_LED_ENABLE
-#include "sleep_led.h"
-#endif
 #include "suspend.h"
 #include "action.h"
 #include "action_util.h"
+#include "hook.h"
 
 
 /**************************************************************************
@@ -653,24 +651,17 @@ ISR(USB_GEN_vect)
         intbits = UDINT;
         UDINT = 0;
         if ((intbits & (1<<SUSPI)) && (UDIEN & (1<<SUSPE)) && usb_configuration) {
-#ifdef SLEEP_LED_ENABLE
-            sleep_led_enable();
-#endif
+            hook_usb_suspend_entry();
             UDIEN &= ~(1<<SUSPE);
             UDIEN |= (1<<WAKEUPE);
             suspend = true;
         }
         if ((intbits & (1<<WAKEUPI)) && (UDIEN & (1<<WAKEUPE)) && usb_configuration) {
             suspend_wakeup_init();
-#ifdef SLEEP_LED_ENABLE
-            sleep_led_disable();
-            // NOTE: converters may not accept this
-            led_set(host_keyboard_leds());
-#endif
-
             UDIEN |= (1<<SUSPE);
             UDIEN &= ~(1<<WAKEUPE);
             suspend = false;
+            hook_usb_wakeup();
         }
         if (intbits & (1<<EORSTI)) {
 		UENUM = 0;

--- a/protocol/vusb.mk
+++ b/protocol/vusb.mk
@@ -2,7 +2,7 @@ VUSB_DIR = protocol/vusb
 
 OPT_DEFS += -DPROTOCOL_VUSB
 
-SRC +=	$(VUSB_DIR)/main.c \
+SRC +=	$(VUSB_DIR)/vusbhooks.c \
 	$(VUSB_DIR)/vusb.c \
 	$(VUSB_DIR)/usbdrv/usbdrv.c \
 	$(VUSB_DIR)/usbdrv/usbdrvasm.S \

--- a/protocol/vusb/main.c
+++ b/protocol/vusb/main.c
@@ -7,94 +7,48 @@
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
  * This Revision: $Id: main.c 790 2010-05-30 21:00:26Z cs $
  */
-#include <stdint.h>
-#include <avr/interrupt.h>
 #include <avr/wdt.h>
-#include <avr/sleep.h>
-#include <util/delay.h>
-#include "usbdrv.h"
-#include "oddebug.h"
-#include "vusb.h"
-#include "keyboard.h"
 #include "host.h"
-#include "timer.h"
 #include "uart.h"
-#include "debug.h"
-
+#include "main.h"
 
 #define UART_BAUD_RATE 115200
 
-
-/* This is from main.c of USBaspLoader */
-static void initForUsbConnectivity(void)
-{
-    uint8_t i = 0;
-
-    usbInit();
-    /* enforce USB re-enumerate: */
-    usbDeviceDisconnect();  /* do this while interrupts are disabled */
-    while(--i){         /* fake USB disconnect for > 250 ms */
-        wdt_reset();
-        _delay_ms(1);
-    }
-    usbDeviceConnect();
-    sei();
-}
-
 int main(void)
 {
-    bool suspended = false;
-#if USB_COUNT_SOF
-    uint16_t last_timer = timer_read();
-#endif
-
     CLKPR = 0x80, CLKPR = 0;
 #ifndef NO_UART
     uart_init(UART_BAUD_RATE);
 #endif
+    mainfunction();
+}
 
-    keyboard_init();
-    host_set_driver(vusb_driver());
+__attribute__((weak))
+void hook_early_init(void) {}
 
-    debug("initForUsbConnectivity()\n");
-    initForUsbConnectivity();
+__attribute__((weak))
+void hook_late_init(void) {}
 
-    debug("main loop\n");
-    while (1) {
-#if USB_COUNT_SOF
-        if (usbSofCount != 0) {
-            suspended = false;
-            usbSofCount = 0;
-            last_timer = timer_read();
-        } else {
-            // Suspend when no SOF in 3ms-10ms(7.1.7.4 Suspending of USB1.1)
-            if (timer_elapsed(last_timer) > 5) {
-                suspended = true;
-/*
-                uart_putchar('S');
-                _delay_ms(1);
-                cli();
-                set_sleep_mode(SLEEP_MODE_PWR_DOWN);
-                sleep_enable();
-                sleep_bod_disable();
-                sei();
-                sleep_cpu();
-                sleep_disable();
-                _delay_ms(10);
-                uart_putchar('W');
-*/
-            }
-        }
+ __attribute__((weak))
+void hook_usb_suspend_entry(void)
+{
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_enable();
 #endif
-        if (!suspended) {
-            usbPoll();
+}
 
-            // TODO: configuration process is incosistent. it sometime fails.
-            // To prevent failing to configure NOT scan keyboard during configuration
-            if (usbConfiguration && usbInterruptIsReady()) {
-                keyboard_task();
-            }
-            vusb_transfer_keyboard();
-        }
-    }
+__attribute__((weak))
+void hook_usb_suspend_loop(void)
+{
+    suspend_power_down();
+}
+
+__attribute__((weak))
+void hook_usb_wakeup(void)
+{
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_disable();
+    // NOTE: converters may not accept this
+    led_set(host_keyboard_leds());
+#endif
 }

--- a/protocol/vusb/vusb.c
+++ b/protocol/vusb/vusb.c
@@ -168,6 +168,7 @@ static host_driver_t driver = {
 static host_driver_configuration_t driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 1,
+  .connection_timeout = 0,
   .drivers = {&driver}
 };
 

--- a/protocol/vusb/vusb.c
+++ b/protocol/vusb/vusb.c
@@ -147,11 +147,7 @@ static bool is_suspended(void) { return suspended; }
 static bool is_remote_wakeup_supported(void) {return false;}
 static void usb_remote_wakeup(void) {}
 
-void protocol_early_init(void) {
-}
-
-
-static host_driver_t driver = {
+host_driver_t vusb_driver = {
         usbInit,
         is_connected,
         is_suspended,
@@ -164,24 +160,6 @@ static host_driver_t driver = {
         send_system,
         send_consumer
 };
-
-static host_driver_configuration_t driver_configuration = {
-  .num_drivers = 1,
-  .connection_delay = 1,
-  .connection_timeout = 0,
-  .drivers = {&driver}
-};
-
-host_driver_t *vusb_driver(void)
-{
-    return &driver;
-}
-
-__attribute__((weak))
-host_driver_configuration_t* hook_get_driver_configuration(void) {
-    return &driver_configuration;
-}
-
 
 static uint8_t keyboard_leds(void) {
     return vusb_keyboard_leds;

--- a/protocol/vusb/vusb.h
+++ b/protocol/vusb/vusb.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host_driver.h"
 
 
-host_driver_t *vusb_driver(void);
+extern host_driver_t vusb_driver;
 void vusb_transfer_keyboard(void);
 
 #endif

--- a/protocol/vusb/vusbhooks.c
+++ b/protocol/vusb/vusbhooks.c
@@ -8,19 +8,31 @@
  * This Revision: $Id: main.c 790 2010-05-30 21:00:26Z cs $
  */
 #include <avr/wdt.h>
+#include "vusb.h"
 #include "host.h"
 #include "uart.h"
-#include "main.h"
+#include "hook.h"
+#include "suspend.h"
 
 #define UART_BAUD_RATE 115200
 
-int main(void)
-{
+static host_driver_configuration_t driver_configuration = {
+  .num_drivers = 1,
+  .connection_delay = 1,
+  .connection_timeout = 0,
+  .drivers = {&vusb_driver}
+};
+
+__attribute__((weak))
+host_driver_configuration_t* hook_get_driver_configuration(void) {
+    return &driver_configuration;
+}
+
+void hook_platform_init(void) {
     CLKPR = 0x80, CLKPR = 0;
 #ifndef NO_UART
     uart_init(UART_BAUD_RATE);
 #endif
-    mainfunction();
 }
 
 __attribute__((weak))

--- a/protocol/vusb/vusbhooks.c
+++ b/protocol/vusb/vusbhooks.c
@@ -20,6 +20,7 @@ static host_driver_configuration_t driver_configuration = {
   .num_drivers = 1,
   .connection_delay = 1,
   .connection_timeout = 0,
+  .try_connect_all = false,
   .drivers = {&vusb_driver}
 };
 

--- a/tool/chibios/chibios.mk
+++ b/tool/chibios/chibios.mk
@@ -142,7 +142,7 @@ CSRC = $(STARTUPSRC) \
        $(BOARDSRC) \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
        $(TMK_DIR)/protocol/chibios/usb_main.c \
-       $(TMK_DIR)/protocol/chibios/main.c \
+       $(TMK_DIR)/protocol/chibios/chibioshooks.c \
        $(SRC)
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global

--- a/tool/chibios/common.mk
+++ b/tool/chibios/common.mk
@@ -1,5 +1,6 @@
 COMMON_DIR = $(TMK_DIR)/common
 SRC +=	$(COMMON_DIR)/host.c \
+	$(COMMON_DIR)/main.c \
 	$(COMMON_DIR)/keyboard.c \
 	$(COMMON_DIR)/action.c \
 	$(COMMON_DIR)/action_tapping.c \


### PR DESCRIPTION
This is a big change, which combines all the main functions of 
1. Chibios
2. Pjrc
3. Lufa
4. Mbed
5. Vusb
6. Blufruit

And not part of this changelist, but supported
1. Infinity Ergodox
2. HHKB rn42 (See a separate pull request)

Into a single generic one. The different functionality is implemented using hooks, but perhaps more importantly by adding a driver configuration, which let you specify the connection mode, and the set of drivers to use. 

There's still only one active driver like before, but additional drivers can connected, and the driver can even be selected on the fly like the HHKB rn42 driver does. Read the documentation in the host_driver.h file for more information.

The motivation for this pull request, was that you didn't accept my simple pull request https://github.com/tmk/tmk_core/pull/9, which would have let me do what I wanted for the Infinity Ergodox, with very little risk of breaking anything. This pull request replaces that, in a much more generic and flexible way, but is way more risky. On the other hand, with the future in mind, this would be a much better approach IMO

I have compiled all the following configurations (and a few more)
1. Chibios - Infinity Ergodox
2. Pjrc - GH60 pjrc
3. Lufa - GH60
4. Mbed - Mbed_Onekey
5. Vusb - Onekey vusb
6. Blufruit - terminal_bluefruit converter
7. rn42 - HHKB

However due to lack of hardware, I have only been able to test the Infinity Ergodox.

Also note that Iwrap has not been converted, due to the fact that I didn't find any keyboard project that uses it.
