### PR TITLE
sleep_led only on when breathing_table != 0

### DIFF
--- a/common/avr/sleep_led.c
+++ b/common/avr/sleep_led.c
@@ -92,7 +92,7 @@ ISR(TIMER1_COMPA_vect)
     timer.row++;
     
     // LED on
-    if (timer.pwm.count == 0) {
+    if (timer.pwm.count == 0 && pgm_read_byte(&breathing_table[timer.pwm.index]) != 0 ) {
         sleep_led_on();
     }
     // LED off

--- a/common/chibios/sleep_led.c
+++ b/common/chibios/sleep_led.c
@@ -62,7 +62,7 @@ OSAL_IRQ_HANDLER(TIMER_INTERRUPT_VECTOR) {
     timer.row++;
 
     // LED on
-    if (timer.pwm.count == 0) {
+    if (timer.pwm.count == 0 && breathing_table[timer.pwm.index] != 0 ) {
         led_set(1<<USB_LED_CAPS_LOCK);
     }
     // LED off


### PR DESCRIPTION
Allow sleep_led animation to completely turn off the LED when breathing_table value is 0 instead of continuing to PWM it. Having the sleep_led off instead of on but very dim is more pleasing to look at. 