### PR TITLE
Use usbWakeupHost instead of send_remote_wakeup

### DIFF
--- a/protocol/chibios/main.c
+++ b/protocol/chibios/main.c
@@ -72,7 +72,7 @@ void hook_usb_suspend_loop(void) {
   suspend_power_down(); // on AVR this deep sleeps for 15ms
   /* Remote wakeup */
   if((USB_DRIVER.status & 2) && suspend_wakeup_condition()) {
-    send_remote_wakeup(&USB_DRIVER);
+    usbWakeupHost(&USB_DRIVER);
   }
 }
 

--- a/protocol/chibios/usb_main.c
+++ b/protocol/chibios/usb_main.c
@@ -657,6 +657,7 @@ static const USBDescriptor *usb_get_descriptor_cb(USBDriver *usbp, uint8_t dtype
       return &nkro_hid_descriptor;
 #endif /* NKRO_ENABLE */
     }
+    break;
 
   case USB_DESCRIPTOR_HID_REPORT:       /* HID Report Descriptor */
     switch(lang) {

--- a/protocol/chibios/usb_main.c
+++ b/protocol/chibios/usb_main.c
@@ -1038,27 +1038,6 @@ void init_usb_driver(USBDriver *usbp) {
 #endif
 }
 
-/*
- * Send remote wakeup packet
- * Note: should not be called from ISR
- */
-void send_remote_wakeup(USBDriver *usbp) {
-  (void)usbp;
-#if defined(K20x) || defined(KL2x)
-#if KINETIS_USB_USE_USB0
-  USB0->CTL |= USBx_CTL_RESUME;
-  chThdSleepMilliseconds(15);
-  USB0->CTL &= ~USBx_CTL_RESUME;
-#endif /* KINETIS_USB_USE_USB0 */
-#elif defined(STM32F0XX) || defined(STM32F1XX) /* K20x || KL2x */
-  STM32_USB->CNTR |= CNTR_RESUME;
-  chThdSleepMilliseconds(15);
-  STM32_USB->CNTR &= ~CNTR_RESUME;
-#else /* STM32F0XX || STM32F1XX */
-#warning Sending remote wakeup packet not implemented for your platform.
-#endif /* K20x || KL2x */
-}
-
 /* ---------------------------------------------------------
  *                  Keyboard functions
  * ---------------------------------------------------------

--- a/protocol/chibios/usb_main.h
+++ b/protocol/chibios/usb_main.h
@@ -36,9 +36,6 @@
 /* Initialize the USB driver and bus */
 void init_usb_driver(USBDriver *usbp);
 
-/* Send remote wakeup packet */
-void send_remote_wakeup(USBDriver *usbp);
-
 /* ---------------
  * Keyboard header
  * ---------------

--- a/protocol/chibios/usb_main.h
+++ b/protocol/chibios/usb_main.h
@@ -49,8 +49,8 @@ void init_usb_driver(USBDriver *usbp);
 
 /* secondary keyboard */
 #ifdef NKRO_ENABLE
-#define NKRO_INTERFACE    EXTRA_INTERFACE+1
-#define NKRO_ENDPOINT     EXTRA_ENDPOINT+1
+#define NKRO_INTERFACE    (EXTRA_INTERFACE+1)
+#define NKRO_ENDPOINT     (EXTRA_ENDPOINT+1)
 #define NKRO_EPSIZE       16
 #define NKRO_REPORT_KEYS  (NKRO_EPSIZE - 1)
 #else


### PR DESCRIPTION
usbWakeupHost is provided by ChibiOS since 17.6.1.
Thus tmk_core doesn't need to provide different send_remote_wakeup() functions.