### PR TITLE
Fix GitHub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ TMK Keyboard Firmware Core Library
 ==================================
 This is a keyboard firmware library with some useful features for Atmel AVR and Cortex-M.
 
-Source code is available here: <https://github.com/tmk/tmk_keyboard/tree/core>
+Source code is available here: <https://github.com/tmk/tmk_core>
 
 
 Updates


### PR DESCRIPTION
The link seems to point to an old place before repositories seem to have been split up.